### PR TITLE
Updated download URLs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,9 +19,9 @@ else
 		fi
 
 		ZIP="${ASDF_INSTALL_VERSION}.zip"
-		curl -OJL https://dl.bintray.com/groovy/maven/${ZIP}
-		unzip -o ${ZIP}
-		rm ${ZIP}
+		curl -OJL "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/${ZIP}"
+		unzip -o "${ZIP}"
+		rm "${ZIP}"
 
 		cp -R groovy-*/* .
 		rm -rf groovy-*/

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-curl -s https://dl.bintray.com/groovy/maven/ | grep -e ".*apache-groovy-binary.*.zip\"" | sed -e "s#^.*:##" -e "s#.zip.*##" -e "s#^apache-groovy-binary-##" | sort -t. -n | paste -s -d" " -
-#curl -s https://dl.bintray.com/groovy/maven/ | grep -e ".*-binary.*.zip\"" | sed -e "s#^.*:##" -e "s#.zip.*##" -e "s#[a-z0-9\-]*\-##" | sort -t. -n | paste -s -d" " -
+curl -s https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/ | grep -e '.*apache-groovy-binary.*.zip"' | cut -d '"' -f 2 | sed -e 's#^apache-groovy-binary-##' -e 's#.zip$##' | sort --version-sort | xargs echo


### PR DESCRIPTION
Fixes #7

Checked the current download URLs at https://groovy.apache.org/download.html
Looks like Groovy distribution has permanently relocated from Bintray to Artifactory.